### PR TITLE
Fix podspec filename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@joinflux/capacitor-segment",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joinflux/capacitor-segment",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A Capacitor plugin for Segment analytics",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -11,7 +11,7 @@
     "android/build.gradle",
     "dist/",
     "ios/Plugin/",
-    "CapacitorSegment.podspec"
+    "JoinfluxCapacitorSegment.podspec"
   ],
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Without the correct filename we are unable to use the plugin in iOS
