### PR TITLE
Fix initialize type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joinflux/capacitor-segment",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A Capacitor plugin for Segment analytics",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,4 +1,3 @@
-
 export interface CapacitorSegmentPlugin {
   initialize(options: InitializeOptions): Promise<void>;
   identify(options: IdentifyOptions): Promise<void>;
@@ -8,19 +7,20 @@ export interface CapacitorSegmentPlugin {
 }
 
 export type InitializeOptions = {
-  key: string
-}
+  key: string;
+  trackLifecycle?: boolean;
+};
 
-export type Identity = { userId: string }
+export type Identity = { userId: string };
 
-export type IdentifyOptions = Identity & { 
-  traits?: Record<string, unknown>
-  options?: Record<string, unknown>
-}
+export type IdentifyOptions = Identity & {
+  traits?: Record<string, unknown>;
+  options?: Record<string, unknown>;
+};
 
 export type TrackOptions = {
-  eventName: string
-  properties: Record<string, unknown>
-}
+  eventName: string;
+  properties: Record<string, unknown>;
+};
 
-export type PageOptions = { pathname: string }
+export type PageOptions = { pathname: string };


### PR DESCRIPTION
This allows the consumer to configure automatic lifecycle events. It had already
been implemented but never exported.
