### PR TITLE
(android) Disable new lifecycle methods

### DIFF
--- a/android/src/main/java/com/joinflux/flux/capacitorsegment/CapacitorSegmentPlugin.java
+++ b/android/src/main/java/com/joinflux/flux/capacitorsegment/CapacitorSegmentPlugin.java
@@ -35,7 +35,7 @@ public class CapacitorSegmentPlugin extends Plugin {
         Builder builder = new Analytics.Builder(context, key);
         Boolean trackLifecycle = call.getBoolean("trackLifecycle", false);
         if (trackLifecycle) {
-            builder.trackApplicationLifecycleEvents();
+            builder.trackApplicationLifecycleEvents().experimentalUseNewLifecycleMethods(false);
         }
 
         Boolean recordScreenViews = call.getBoolean("recordScreenViews", false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@joinflux/capacitor-segment",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@joinflux/capacitor-segment",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joinflux/capacitor-segment",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Capacitor plugin for Segment analytics",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
These seem to not be compatible with the current Android build, without it
Android apps crash on boot.
