### PR TITLE
(Android) Attempt to fix "Duplicate analytics client created with tag:..." error

### DIFF
--- a/android/src/main/java/com/joinflux/flux/segment/SegmentPlugin.java
+++ b/android/src/main/java/com/joinflux/flux/segment/SegmentPlugin.java
@@ -22,10 +22,12 @@ public class SegmentPlugin extends Plugin {
     @PluginMethod
     public void initialize(PluginCall call) {
         synchronized(implementation) {
+            // No-op
             if (initialized == true) {
-                call.reject("Segment is already initialized");
+                call.resolve();
                 return;
             }
+
             String key = call.getString("key");
             if (key == null) {
                 call.reject("Write key is required to initialize plugin");

--- a/android/src/main/java/com/joinflux/flux/segment/SegmentPlugin.java
+++ b/android/src/main/java/com/joinflux/flux/segment/SegmentPlugin.java
@@ -16,35 +16,37 @@ import com.segment.analytics.Traits;
 @CapacitorPlugin(name = "Segment")
 public class SegmentPlugin extends Plugin {
 
-    private boolean initialized = false;
-    private Segment implementation = new Segment();
+    private static boolean initialized = false;
+    private static Segment implementation = new Segment();
 
     @PluginMethod
     public void initialize(PluginCall call) {
-        if (initialized == true) {
-            call.reject("Segment is already initialized");
-            return;
-        }
-        String key = call.getString("key");
-        if (key == null) {
-            call.reject("Write key is required to initialize plugin");
-            return;
-        }
+        synchronized(implementation) {
+            if (initialized == true) {
+                call.reject("Segment is already initialized");
+                return;
+            }
+            String key = call.getString("key");
+            if (key == null) {
+                call.reject("Write key is required to initialize plugin");
+                return;
+            }
 
-        Context context = this.getContext();
-        Builder builder = new Analytics.Builder(context, key);
-        Boolean trackLifecycle = call.getBoolean("trackLifecycle", false);
-        if (trackLifecycle) {
-            builder.trackApplicationLifecycleEvents().experimentalUseNewLifecycleMethods(false);
-        }
+            Context context = this.getContext();
+            Builder builder = new Analytics.Builder(context, key);
+            Boolean trackLifecycle = call.getBoolean("trackLifecycle", false);
+            if (trackLifecycle) {
+                builder.trackApplicationLifecycleEvents().experimentalUseNewLifecycleMethods(false);
+            }
 
-        Boolean recordScreenViews = call.getBoolean("recordScreenViews", false);
-        if (recordScreenViews) {
-            builder.recordScreenViews();
+            Boolean recordScreenViews = call.getBoolean("recordScreenViews", false);
+            if (recordScreenViews) {
+                builder.recordScreenViews();
+            }
+            initialized = true;
+            implementation.analytics = builder.build();
+            call.resolve();
         }
-        initialized = true;
-        implementation.analytics = builder.build();
-        call.resolve();
     }
 
     @PluginMethod

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joinflux/capacitor-segment",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Capacitor plugin for Segment analytics",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Alternative implementation for https://github.com/joinflux/capacitor-segment/pull/16

Instead of forcing the analytics client to be a singleton, this PR ensures the "plugin" is only initialized once