### PR TITLE
(android, ios, web) add the ability to configure proxying http calls

### DIFF
--- a/android/src/main/java/com/joinflux/flux/segment/SegmentPlugin.java
+++ b/android/src/main/java/com/joinflux/flux/segment/SegmentPlugin.java
@@ -32,7 +32,26 @@ public class SegmentPlugin extends Plugin {
             }
 
             Context context = this.getContext();
-            Builder builder = new Analytics.Builder(context, key);
+
+            Builder builder;
+            String proxyHost = call.getString("proxyHost");
+
+            if (proxyHost == null) {
+                builder = new Analytics.Builder(context, key);
+            } else {
+                builder =
+                    new Analytics.Builder(context, key)
+                        .connectionFactory(
+                            new ConnectionFactory() {
+                                @Override
+                                protected HttpURLConnection openConnection(String url) throws IOException {
+                                    String path = Uri.parse(url).getPath();
+                                    return super.openConnection(proxyHost + path);
+                                }
+                            }
+                        );
+            }
+
             boolean trackLifecycle = Boolean.TRUE.equals(call.getBoolean("trackLifecycle", false));
             if (trackLifecycle) {
                 builder.trackApplicationLifecycleEvents().experimentalUseNewLifecycleMethods(false);

--- a/ios/Plugin/Segment.swift
+++ b/ios/Plugin/Segment.swift
@@ -5,6 +5,19 @@ import Segment
     @objc public func initialize(key: String, trackLifecycle: Bool) {
         let config = AnalyticsConfiguration.init(writeKey: key)
         config.trackApplicationLifecycleEvents = trackLifecycle;
+
+        if(!proxyHost.isEmpty) {
+            config.requestFactory = { (url: URL) -> NSMutableURLRequest in
+                var result = NSMutableURLRequest(url: url)
+                if var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+                    components.host = proxyHost
+                    if let transformedURL = components.url {
+                        result = NSMutableURLRequest(url: transformedURL)
+                    }
+                }
+                return result
+            }
+        }
         
         Analytics.setup(with: config)
         print("CapacitorSegment: initialized")

--- a/ios/Plugin/SegmentPlugin.swift
+++ b/ios/Plugin/SegmentPlugin.swift
@@ -20,7 +20,8 @@ public class SegmentPlugin: CAPPlugin {
             return
         }
         let trackLifecycle = call.getBool("trackLifecycle", false)
-        implementation.initialize(key: key, trackLifecycle: trackLifecycle)
+        let proxyHost = call.getString("proxyHost", "")
+        implementation.initialize(key: key, trackLifecycle: trackLifecycle, proxyHost: proxyHost)
         initialized = true
         call.resolve()
     }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -10,6 +10,7 @@ export type InitializeOptions = {
   key: string;
   trackLifecycle?: boolean;
   recordScreenViews?: boolean;
+  proxyHost?: string;
 };
 
 export type Identity = { userId: string };

--- a/src/web.ts
+++ b/src/web.ts
@@ -10,7 +10,8 @@ import type {
 
 const getSegmentScript = (
   key: string,
-) => `!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="${key}";analytics.SNIPPET_VERSION="4.13.2";
+  proxyHost?: string
+) => `!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="${proxyHost ? proxyHost + '/analytics.js/v1/' : 'https://cdn.segment.com/analytics.js/v1/'}" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="${key}";analytics.SNIPPET_VERSION="4.13.2";
 analytics.load("${key}");
 analytics.page();
 }}();`;
@@ -22,7 +23,7 @@ declare global {
 }
 export class SegmentWeb extends WebPlugin implements SegmentPlugin {
   async initialize(options: InitializeOptions): Promise<void> {
-    await this.loadScript('segment', getSegmentScript(options.key));
+    await this.loadScript('segment', getSegmentScript(options.key, options.proxyHost));
   }
 
   async identify(options: IdentifyOptions): Promise<void> {


### PR DESCRIPTION
It is suggested to add the ability to configure http proxy

docs: https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#proxying-http-calls

It was tested on ios, android and web.