### PR TITLE
feat: add optional properties to the page() API call + add "prepare" script to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ track(options: TrackOptions) => any
 page(options: PageOptions) => any
 ```
 
-| Param         | Type                               |
-| ------------- | ---------------------------------- |
-| **`options`** | <code>{ pathname: string; }</code> |
+| Param         | Type                                                |
+| ------------- |-----------------------------------------------------|
+| **`options`** | <code>{ pathname: string; properties: any; }</code> |
 
 **Returns:** <code>any</code>
 

--- a/android/src/main/java/com/joinflux/flux/segment/Segment.java
+++ b/android/src/main/java/com/joinflux/flux/segment/Segment.java
@@ -27,9 +27,12 @@ public class Segment {
         this.analytics.track(eventName, makePropertiesFromMap(makeMapFromJSON(properties)), makeOptionsFromJSON(options));
     }
 
-    public void page(String pathname) {
-        this.analytics.screen(pathname);
-    }
+    public void page(String pathname, JSObject properties) {
+        this.analytics.screen(
+                pathname,
+                makePropertiesFromMap(makeMapFromJSON(properties))
+        );
+    }}
 
     public void reset() {
         this.analytics.reset();

--- a/android/src/main/java/com/joinflux/flux/segment/Segment.java
+++ b/android/src/main/java/com/joinflux/flux/segment/Segment.java
@@ -32,7 +32,7 @@ public class Segment {
                 pathname,
                 makePropertiesFromMap(makeMapFromJSON(properties))
         );
-    }}
+    }
 
     public void reset() {
         this.analytics.reset();

--- a/android/src/main/java/com/joinflux/flux/segment/SegmentPlugin.java
+++ b/android/src/main/java/com/joinflux/flux/segment/SegmentPlugin.java
@@ -94,8 +94,9 @@ public class SegmentPlugin extends Plugin {
             call.reject("Pathname was not supplied");
             return;
         }
+        JSObject properties = call.getObject("properties");
 
-        implementation.page(pathname);
+        implementation.page(pathname, properties);
         call.resolve();
     }
 

--- a/ios/Plugin/Segment.swift
+++ b/ios/Plugin/Segment.swift
@@ -20,11 +20,12 @@ import Segment
         return
     }
 
-    @objc public func page(pathname: String) {
-        Analytics.shared().screen(pathname)
+
+    @objc public func page(pathname: String, properties: Dictionary<String, Any>) {
+        Analytics.shared().screen(pathname, properties: properties)
         return
     }
-    
+
     @objc func reset() {
         Analytics.shared().reset()
         return

--- a/ios/Plugin/SegmentPlugin.swift
+++ b/ios/Plugin/SegmentPlugin.swift
@@ -65,8 +65,10 @@ public class SegmentPlugin: CAPPlugin {
             call.reject("Pathname was not supplied")
             return
         }
-        
-        implementation.page(pathname: pathname)
+        let properties: Dictionary = call.getObject("properties") ?? [:]
+
+
+        implementation.page(pathname: pathname, properties: properties)
         call.resolve()
     }
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@joinflux/capacitor-segment",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@joinflux/capacitor-segment",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "native"
   ],
   "scripts": {
+    "prepare": "npm run build",
     "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",
     "verify:ios": "cd ios && pod install && xcodebuild -workspace Plugin.xcworkspace -scheme Plugin -destination generic/platform=iOS && cd ..",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -24,4 +24,5 @@ export type TrackOptions = {
   properties: Record<string, unknown>;
 };
 
-export type PageOptions = { pathname: string };
+export type PageOptions = { pathname: string, properties: Record<string, unknown> };
+

--- a/src/web.ts
+++ b/src/web.ts
@@ -43,7 +43,7 @@ export class SegmentWeb extends WebPlugin implements SegmentPlugin {
   async page(options: PageOptions): Promise<void> {
     if (!window.analytics) return Promise.reject('Segment is not initialized');
     if (!options.pathname) return Promise.reject('Pathname was not supplied');
-    window.analytics.page(options.pathname);
+    window.analytics.page(options.pathname, options.properties)
   }
 
   async reset(): Promise<void> {


### PR DESCRIPTION
The official segment documentation tell us that we can pass additional properties to the `track` API call : https://segment.com/docs/connections/spec/track/.

Native SDKs (iOS and Android) both support this so my pull request is a proposal to add this feature into the package 😄 

Side effect: 
I also added the `prepare` property to scripts in the `package.json` to be able to install the package right from your local environment or from Github)