### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @joinflux/engineering


### PR DESCRIPTION
This should help us enforce auto reviews from the Engineering team.
